### PR TITLE
Fix incorrect alt text

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -546,7 +546,7 @@
     <link href="http://sah.tw/blog/2017/08/05/high-availability-production-environment-issue/"/>
     <updated>2017-08-05T16:20:09+08:00</updated>
     <id>http://sah.tw/blog/2017/08/05/high-availability-production-environment-issue</id>
-    <content type="html"><![CDATA[<p>​ <img src="http://mrshih.github.io/images/2017-08-05-high-availability-production-environment-issue.jpg" alt="2017-08-05-high-availability-production-environment-issu" /></p>
+    <content type="html"><![CDATA[<p>​ <img src="http://mrshih.github.io/images/2017-08-05-high-availability-production-environment-issue.jpg" alt="2017-08-05-high-availability-production-environment-issue" /></p>
 
 <p>要上線一個系統，或更新一個系統的版本，首先最重要的就是系統穩定度。有些系統比如在銀行，上線後出了問題都是非常緊急的，一但系統上線開放給別人來使用，背後需要考慮的完善，才不會上線之後一直在救火救不完。</p>
 

--- a/blog/2017/08/05/high-availability-production-environment-issue/index.html
+++ b/blog/2017/08/05/high-availability-production-environment-issue/index.html
@@ -107,7 +107,7 @@
   </header>
 
 
-<div class="entry-content"><p>​ <img src="http://mrshih.github.io/images/2017-08-05-high-availability-production-environment-issue.jpg" alt="2017-08-05-high-availability-production-environment-issu" /></p>
+<div class="entry-content"><p>​ <img src="http://mrshih.github.io/images/2017-08-05-high-availability-production-environment-issue.jpg" alt="2017-08-05-high-availability-production-environment-issue" /></p>
 
 <p>要上線一個系統，或更新一個系統的版本，首先最重要的就是系統穩定度。有些系統比如在銀行，上線後出了問題都是非常緊急的，一但系統上線開放給別人來使用，背後需要考慮的完善，才不會上線之後一直在救火救不完。</p>
 

--- a/blog/categories/gong-jiang/atom.xml
+++ b/blog/categories/gong-jiang/atom.xml
@@ -18,7 +18,7 @@
     <link href="http://sah.tw/blog/2017/08/05/high-availability-production-environment-issue/"/>
     <updated>2017-08-05T16:20:09+08:00</updated>
     <id>http://sah.tw/blog/2017/08/05/high-availability-production-environment-issue</id>
-    <content type="html"><![CDATA[<p>​ <img src="http://mrshih.github.io/images/2017-08-05-high-availability-production-environment-issue.jpg" alt="2017-08-05-high-availability-production-environment-issu" /></p>
+    <content type="html"><![CDATA[<p>​ <img src="http://mrshih.github.io/images/2017-08-05-high-availability-production-environment-issue.jpg" alt="2017-08-05-high-availability-production-environment-issue" /></p>
 
 <p>要上線一個系統，或更新一個系統的版本，首先最重要的就是系統穩定度。有些系統比如在銀行，上線後出了問題都是非常緊急的，一但系統上線開放給別人來使用，背後需要考慮的完善，才不會上線之後一直在救火救不完。</p>
 

--- a/index.html
+++ b/index.html
@@ -880,7 +880,7 @@
   </header>
 
 
-  <div class="entry-content"><p>​ <img src="http://mrshih.github.io/images/2017-08-05-high-availability-production-environment-issue.jpg" alt="2017-08-05-high-availability-production-environment-issu" /></p>
+  <div class="entry-content"><p>​ <img src="http://mrshih.github.io/images/2017-08-05-high-availability-production-environment-issue.jpg" alt="2017-08-05-high-availability-production-environment-issue" /></p>
 
 <p>要上線一個系統，或更新一個系統的版本，首先最重要的就是系統穩定度。有些系統比如在銀行，上線後出了問題都是非常緊急的，一但系統上線開放給別人來使用，背後需要考慮的完善，才不會上線之後一直在救火救不完。</p>
 


### PR DESCRIPTION
## Summary
- correct a typo in the image alt text used in blog entry and feed

## Testing
- `npm test` *(fails: `package.json` not found)*
- `make test` *(fails: no rule for `test`)*